### PR TITLE
Update to Alpine 3.18

### DIFF
--- a/plone/Dockerfile
+++ b/plone/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 AS build-stage
+FROM 4teamwork/python:2.7 as build-stage
 
 RUN addgroup -S -g 800 plone \
  && adduser -S -D -G plone -u 800 plone
@@ -13,21 +13,16 @@ RUN apk add --virtual .build-deps \
     libpng-dev \
     libxml2-dev \
     libxslt-dev \
-    python2-dev \
     gettext
 
 WORKDIR /app
 
-RUN wget https://bootstrap.pypa.io/virtualenv/2.7/virtualenv.pyz \
- && python virtualenv.pyz . \
- && rm virtualenv.pyz
-
-ENV VIRTUAL_ENV=/app
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN echo "/app/lib/python2.7/site-packages/" > /usr/local/lib/python2.7/site-packages/app.pth
 
 COPY versions.txt ./
 
-RUN --mount=type=cache,target=/root/.cache pip install Plone Products.PloneHotfix20210518 -c versions.txt
+RUN --mount=type=cache,target=/root/.cache pip install --prefix /app Plone Products.PloneHotfix20210518 -c versions.txt
+
 
 # Fix missing .mo files in p.a.discussion
 RUN find /app/lib/python2.7/site-packages/plone/app/discussion/i18n -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo'
@@ -38,7 +33,7 @@ RUN mkdir -p /app/var /app/etc \
 COPY etc /app/etc
 
 
-FROM alpine:3.14
+FROM 4teamwork/python:2.7
 
 RUN addgroup -S -g 800 plone \
  && adduser -S -D -G plone -u 800 plone
@@ -47,13 +42,11 @@ RUN apk add \
     libxml2 \
     libxslt \
     libjpeg-turbo \
-    tzdata \
-    python2
-
-RUN --mount=type=cache,target=/var/cache/apk apk add --virtual .build-deps \
-    python2
+    tzdata
 
 COPY --from=build-stage /app /app
+RUN echo "/app/lib/python2.7/site-packages/" > /usr/local/lib/python2.7/site-packages/app.pth \
+ && echo "import site; site.addsitedir('/app/lib/python2.7/site-packages')" > /usr/local/lib/python2.7/site-packages/sitecustomize.py
 
 RUN mkdir -p /data/filestorage /data/blobstorage \
  && chown -R plone:plone /data

--- a/plone/Dockerfile
+++ b/plone/Dockerfile
@@ -23,6 +23,8 @@ COPY versions.txt ./
 
 RUN --mount=type=cache,target=/root/.cache pip install --prefix /app Plone Products.PloneHotfix20210518 -c versions.txt
 
+COPY ./patches/z3c_autoinclude_utils.py /app/lib/python2.7/site-packages/z3c/autoinclude/utils.py
+RUN python2.7 -m compileall /app/lib/python2.7/site-packages/z3c/autoinclude/utils.py
 
 # Fix missing .mo files in p.a.discussion
 RUN find /app/lib/python2.7/site-packages/plone/app/discussion/i18n -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo'

--- a/plone/Dockerfile
+++ b/plone/Dockerfile
@@ -13,13 +13,43 @@ RUN apk add --virtual .build-deps \
     libpng-dev \
     libxml2-dev \
     libxslt-dev \
-    gettext
+    gettext \
+    curl \
+    patch
 
 WORKDIR /app
 
 RUN echo "/app/lib/python2.7/site-packages/" > /usr/local/lib/python2.7/site-packages/app.pth
 
 COPY versions.txt ./
+
+COPY patches /var/tmp/patches
+
+# Install Pillow with security patches
+RUN --mount=type=cache,target=/root/.cache \
+ curl -o /var/tmp/Pillow-6.2.2.tar.gz https://files.pythonhosted.org/packages/b3/d0/a20d8440b71adfbf133452d4f6e0fe80de2df7c2578c9b498fb812083383/Pillow-6.2.2.tar.gz \
+ && cd /var/tmp \
+ && tar xzvf Pillow-6.2.2.tar.gz \
+ && rm Pillow-6.2.2.tar.gz \
+ && cd Pillow-6.2.2 \
+ && patch -p 1 -i /var/tmp/patches/CVE-2020-11538.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2020-35653.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2020-35655.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-25290.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-25292.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-25293.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-27921_27922_27923.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-25287_25288.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-28675.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-28676.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-28677.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-28678.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2021-34552.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2022-22817.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2022-22815_CVE-2022-22816.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2023-44271.patch \
+ && patch -p 1 -i /var/tmp/patches/CVE-2023-50447.patch \
+ && pip install /var/tmp/Pillow-6.2.2 --prefix /app
 
 RUN --mount=type=cache,target=/root/.cache pip install --prefix /app Plone Products.PloneHotfix20210518 -c versions.txt
 

--- a/plone/create_zope_conf.py
+++ b/plone/create_zope_conf.py
@@ -25,6 +25,11 @@ def main():
         'zeo_address': env.get('ZEO_ADDRESS', 'zeoserver:8100'),
         'storage': env.get('STORAGE', 'zeoclient')
     }
+    if options['debug_mode'] == 'on':
+        # Avoid duplicate log entries on console
+        options['logfile_loglevel'] = 'CRITICAL'
+    else:
+        options['logfile_loglevel'] = 'INFO'
     if options['verbose_security'] == 'on':
         options['security_implementation'] = 'python'
 
@@ -95,7 +100,7 @@ trusted-proxy 127.0.0.1
   level INFO
   <logfile>
     path STDERR
-    level INFO
+    level {logfile_loglevel}
   </logfile>
 </eventlog>
 

--- a/plone/docker-entrypoint.sh
+++ b/plone/docker-entrypoint.sh
@@ -2,7 +2,14 @@
 INSTANCE_HOME="/app"
 CONFIG_FILE="/app/etc/zope.conf"
 ZOPE_RUN="/app/bin/runzope"
+ZOPE_CTL="/app/bin/zopectl"
 export INSTANCE_HOME
 
 python create_zope_conf.py "$CONFIG_FILE"
-exec "$ZOPE_RUN" -C "$CONFIG_FILE" "$@"
+
+if [ $# -eq 0 ]
+then
+  exec "$ZOPE_RUN" -C "$CONFIG_FILE"
+else
+  exec "$ZOPE_CTL" -C "$CONFIG_FILE" "$@"
+fi

--- a/plone/patches/CVE-2020-11538.patch
+++ b/plone/patches/CVE-2020-11538.patch
@@ -1,0 +1,44 @@
+CVE-2020-11538 out-of-bounds reads/writes in the parsing of SGI image files in expandrow/expandrow2
+
+--- a/src/libImaging/SgiRleDecode.c
++++ b/src/libImaging/SgiRleDecode.c
+@@ -28,6 +28,7 @@
+ static int expandrow(UINT8* dest, UINT8* src, int n, int z, int xsize)
+ {
+     UINT8 pixel, count;
++    int x = 0;
+ 
+     for (;n > 0; n--)
+     {
+@@ -37,9 +38,10 @@
+         count = pixel & RLE_MAX_RUN;
+         if (!count)
+             return count;
+-        if (count > xsize) {
++        if (x + count > xsize) {
+             return -1;
+         }
++        x += count;
+         if (pixel & RLE_COPY_FLAG) {
+             while(count--) {
+                 *dest = *src++;
+@@ -63,6 +65,7 @@
+ {
+     UINT8 pixel, count;
+ 
++    int x = 0;
+ 
+     for (;n > 0; n--)
+     {
+@@ -73,9 +76,10 @@
+         count = pixel & RLE_MAX_RUN;
+         if (!count)
+             return count;
+-        if (count > xsize) {
++        if (x + count > xsize) {
+             return -1;
+         }
++        x += count;
+         if (pixel & RLE_COPY_FLAG) {
+             while(count--) {
+                 memcpy(dest, src, 2);

--- a/plone/patches/CVE-2020-35653.patch
+++ b/plone/patches/CVE-2020-35653.patch
@@ -1,0 +1,32 @@
+CVE-2020-35653 decoding a crafted PCX file could result in buffer over-read
+
+--- a/src/PIL/PcxImagePlugin.py
++++ b/src/PIL/PcxImagePlugin.py
+@@ -68,13 +68,13 @@
+         version = i8(s[1])
+         bits = i8(s[3])
+         planes = i8(s[65])
+-        stride = i16(s, 66)
++        ignored_stride = i16(s, 66)
+         logger.debug(
+             "PCX version %s, bits %s, planes %s, stride %s",
+             version,
+             bits,
+             planes,
+-            stride,
++            ignored_stride,
+         )
+ 
+         self.info["dpi"] = i16(s, 12), i16(s, 14)
+@@ -111,6 +111,11 @@
+ 
+         self.mode = mode
+         self._size = bbox[2] - bbox[0], bbox[3] - bbox[1]
++
++        # don't trust the passed in stride. Calculate for ourselves.
++        # CVE-2020-35653
++        stride = (self.size[0] * bits + 7) // 8
++        stride += stride % 2
+ 
+         bbox = (0, 0) + self.size
+         logger.debug("size: %sx%s", *self.size)

--- a/plone/patches/CVE-2020-35655.patch
+++ b/plone/patches/CVE-2020-35655.patch
@@ -1,0 +1,86 @@
+CVE-2020-35655 decoding crafted SGI RLE image files could result in buffer over-read
+
+--- a/src/libImaging/SgiRleDecode.c
++++ b/src/libImaging/SgiRleDecode.c
+@@ -108,14 +108,33 @@
+     int err = 0;
+     int status;
+ 
++    /* size check */
++    if (im->xsize > INT_MAX / im->bands ||
++        im->ysize > INT_MAX / im->bands) {
++        state->errcode = IMAGING_CODEC_MEMORY;
++        return -1;
++    }
++
+     /* Get all data from File descriptor */
+     c = (SGISTATE*)state->context;
+     _imaging_seek_pyFd(state->fd, 0L, SEEK_END);
+     c->bufsize = _imaging_tell_pyFd(state->fd);
+     c->bufsize -= SGI_HEADER_SIZE;
++
++    c->tablen = im->bands * im->ysize;
++    /* below, we populate the starttab and lentab into the bufsize,
++       each with 4 bytes per element of tablen
++       Check here before we allocate any memory
++    */
++    if (c->bufsize < 8*c->tablen) {
++        state->errcode = IMAGING_CODEC_OVERRUN;
++        return -1;
++    }
++
+     ptr = malloc(sizeof(UINT8) * c->bufsize);
+     if (!ptr) {
+-        return IMAGING_CODEC_MEMORY;
++        state->errcode = IMAGING_CODEC_MEMORY;
++        return -1;
+     }
+     _imaging_seek_pyFd(state->fd, SGI_HEADER_SIZE, SEEK_SET);
+     _imaging_read_pyFd(state->fd, (char*)ptr, c->bufsize);
+@@ -130,18 +149,11 @@
+         state->ystep = 1;
+     }
+ 
+-    if (im->xsize > INT_MAX / im->bands ||
+-        im->ysize > INT_MAX / im->bands) {
+-        err = IMAGING_CODEC_MEMORY;
+-        goto sgi_finish_decode;
+-    }
+-
+     /* Allocate memory for RLE tables and rows */
+     free(state->buffer);
+     state->buffer = NULL;
+     /* malloc overflow check above */
+     state->buffer = calloc(im->xsize * im->bands, sizeof(UINT8) * 2);
+-    c->tablen = im->bands * im->ysize;
+     c->starttab = calloc(c->tablen, sizeof(UINT32));
+     c->lengthtab = calloc(c->tablen, sizeof(UINT32));
+     if (!state->buffer ||
+@@ -170,7 +182,7 @@
+ 
+             if (c->rleoffset + c->rlelength > c->bufsize) {
+                 state->errcode = IMAGING_CODEC_OVERRUN;
+-                return -1;
++                goto sgi_finish_decode;
+             }
+ 
+             /* row decompression */
+@@ -182,7 +194,7 @@
+             }
+             if (status == -1) {
+                 state->errcode = IMAGING_CODEC_OVERRUN;
+-                return -1;
++                goto sgi_finish_decode;
+             } else if (status == 1) {
+                 goto sgi_finish_decode;
+             }
+@@ -203,7 +215,8 @@
+     free(c->lengthtab);
+     free(ptr);
+     if (err != 0){
+-        return err;
++        state->errcode=err;
++        return -1;
+     }
+     return state->count - c->bufsize;
+ }

--- a/plone/patches/CVE-2021-25287_25288.patch
+++ b/plone/patches/CVE-2021-25287_25288.patch
@@ -1,0 +1,117 @@
+CVE-2021-25288 and 25287 out-of-bounds read in J2kDecode in j2ku_gray_i and j2ku_graya_la
+
+--- a/src/libImaging/Jpeg2KDecode.c
++++ b/src/libImaging/Jpeg2KDecode.c
+@@ -110,6 +110,7 @@ j2ku_gray_l(opj_image_t *in, const JPEG2KTILEINFO *tileinfo,
+     if (shift < 0)
+         offset += 1 << (-shift - 1);
+ 
++    /* csiz*h*w + offset = tileinfo.datasize */
+     switch (csiz) {
+     case 1:
+         for (y = 0; y < h; ++y) {
+@@ -557,8 +558,10 @@ j2k_decode_entry(Imaging im, ImagingCodecState state)
+     opj_dparameters_t params;
+     OPJ_COLOR_SPACE color_space;
+     j2k_unpacker_t unpack = NULL;
+-    size_t buffer_size = 0;
+-    unsigned n;
++    size_t buffer_size = 0, tile_bytes = 0;
++    unsigned n, tile_height, tile_width;
++    int total_component_width = 0;
++
+ 
+     stream = opj_stream_create(BUFFER_SIZE, OPJ_TRUE);
+ 
+@@ -703,8 +706,62 @@ j2k_decode_entry(Imaging im, ImagingCodecState state)
+         tile_info.x1 = (tile_info.x1 + correction) >> context->reduce;
+         tile_info.y1 = (tile_info.y1 + correction) >> context->reduce;
+ 
++        /* Check the tile bounds; if the tile is outside the image area,
++           or if it has a negative width or height (i.e. the coordinates are
++           swapped), bail. */
++        if (tile_info.x0 >= tile_info.x1
++            || tile_info.y0 >= tile_info.y1
++            || tile_info.x0 < image->x0
++            || tile_info.y0 < image->y0
++            || tile_info.x1 - image->x0 > im->xsize
++            || tile_info.y1 - image->y0 > im->ysize) {
++            state->errcode = IMAGING_CODEC_BROKEN;
++            state->state = J2K_STATE_FAILED;
++            goto quick_exit;
++        }
++
++        if (tile_info.nb_comps != image->numcomps) {
++            state->errcode = IMAGING_CODEC_BROKEN;
++            state->state = J2K_STATE_FAILED;
++            goto quick_exit;
++        }
++
++        /* Sometimes the tile_info.datasize we get back from openjpeg
++           is less than sum(comp_bytes)*w*h, and we overflow in the
++           shuffle stage */
++
++        tile_width = tile_info.x1 - tile_info.x0;
++        tile_height = tile_info.y1 - tile_info.y0;
++
++        /* Total component width = sum (component_width) e.g, it's
++         legal for an la file to have a 1 byte width for l, and 4 for
++         a. and then a malicious file could have a smaller tile_bytes
++        */
++
++        for (n=0; n < tile_info.nb_comps; n++) {
++            // see csize /acsize calcs
++            int csize = (image->comps[n].prec + 7) >> 3;
++            csize = (csize == 3) ? 4 : csize;
++            total_component_width += csize;
++        }
++        if ((tile_width > UINT_MAX / total_component_width) ||
++            (tile_height > UINT_MAX / total_component_width) ||
++            (tile_width > UINT_MAX / (tile_height * total_component_width)) ||
++            (tile_height > UINT_MAX / (tile_width * total_component_width))) {
++
++            state->errcode = IMAGING_CODEC_BROKEN;
++            state->state = J2K_STATE_FAILED;
++            goto quick_exit;
++        }
++
++        tile_bytes = tile_width * tile_height * total_component_width;
++
++        if (tile_bytes > tile_info.data_size) {
++            tile_info.data_size = tile_bytes;
++        }
++
+         if (buffer_size < tile_info.data_size) {
+-            /* malloc check ok, tile_info.data_size from openjpeg */
++            /* malloc check ok, overflow and tile size sanity check above */
+             UINT8 *new = realloc (state->buffer, tile_info.data_size);
+             if (!new) {
+                 state->errcode = IMAGING_CODEC_MEMORY;
+@@ -715,6 +772,7 @@ j2k_decode_entry(Imaging im, ImagingCodecState state)
+             buffer_size = tile_info.data_size;
+         }
+ 
++
+         if (!opj_decode_tile_data(codec,
+                                   tile_info.tile_index,
+                                   (OPJ_BYTE *)state->buffer,
+@@ -725,20 +783,6 @@ j2k_decode_entry(Imaging im, ImagingCodecState state)
+             goto quick_exit;
+         }
+ 
+-        /* Check the tile bounds; if the tile is outside the image area,
+-           or if it has a negative width or height (i.e. the coordinates are
+-           swapped), bail. */
+-        if (tile_info.x0 >= tile_info.x1
+-            || tile_info.y0 >= tile_info.y1
+-            || tile_info.x0 < image->x0
+-            || tile_info.y0 < image->y0
+-            || tile_info.x1 - image->x0 > im->xsize
+-            || tile_info.y1 - image->y0 > im->ysize) {
+-            state->errcode = IMAGING_CODEC_BROKEN;
+-            state->state = J2K_STATE_FAILED;
+-            goto quick_exit;
+-        }
+-
+         unpack(image, &tile_info, state->buffer, im);
+     }

--- a/plone/patches/CVE-2021-25290.patch
+++ b/plone/patches/CVE-2021-25290.patch
@@ -1,0 +1,15 @@
+CVE-2021-25290 negative-offset memcpy with an invalid size in TiffDecode.c
+
+--- a/src/libImaging/TiffDecode.c
++++ b/src/libImaging/TiffDecode.c
+@@ -36,6 +36,11 @@
+     TRACE(("_tiffReadProc: %d \n", (int)size));
+     dump_state(state);
+ 
++    if (state->loc > state->eof) {
++        TIFFError("_tiffReadProc", "Invalid Read at loc %d, eof: %d", state->loc, state->eof);
++        return 0;
++    }
++
+     to_read = min(size, min(state->size, (tsize_t)state->eof) - (tsize_t)state->loc);
+     TRACE(("to_read: %d\n", (int)to_read));

--- a/plone/patches/CVE-2021-25292.patch
+++ b/plone/patches/CVE-2021-25292.patch
@@ -1,0 +1,15 @@
+CVE-2021-25292 backtracking regex in PDF parser could be used as a DOS attack
+
+--- a/src/PIL/PdfParser.py
++++ b/src/PIL/PdfParser.py
+@@ -628,8 +628,9 @@
+     whitespace_or_hex = br"[\000\011\012\014\015\0400-9a-fA-F]"
+     whitespace_optional = whitespace + b"*"
+     whitespace_mandatory = whitespace + b"+"
++    whitespace_optional_no_nl = br"[\000\011\014\015\040]*"  # no "\012" aka "\n"
+     newline_only = br"[\r\n]+"
+-    newline = whitespace_optional + newline_only + whitespace_optional
++    newline = whitespace_optional_no_nl + newline_only + whitespace_optional_no_nl
+     re_trailer_end = re.compile(
+         whitespace_mandatory
+         + br"trailer"

--- a/plone/patches/CVE-2021-25293.patch
+++ b/plone/patches/CVE-2021-25293.patch
@@ -1,0 +1,197 @@
+CVE-2021-25293 out-of-bounds read in SGIRleDecode.c
+
+--- a/src/libImaging/SgiRleDecode.c
++++ b/src/libImaging/SgiRleDecode.c
+@@ -25,13 +25,60 @@
+     *dest = (UINT32)((buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3]);
+ }
+ 
+-static int expandrow(UINT8* dest, UINT8* src, int n, int z, int xsize)
++/*
++   SgiRleDecoding is done in a single channel row oriented set of RLE chunks.
++
++   * The file is arranged as
++     - SGI Header
++     - Rle Offset Table
++     - Rle Length Table
++     - Scanline Data
++
++   * Each RLE atom is c->bpc bytes wide (1 or 2)
++
++   * Each RLE Chunk is [specifier atom] [ 1 or n data atoms ]
++
++   * Copy Atoms are a byte with the high bit set, and the low 7 are
++     the number of bytes to copy from the source to the
++     destination. e.g.
++
++         CBBBBBBBB or 0CHLHLHLHLHLHL   (B=byte, H/L = Hi low bytes)
++
++   * Run atoms do not have the high bit set, and the low 7 bits are
++     the number of copies of the next atom to copy to the
++     destination. e.g.:
++
++         RB -> BBBBB or RHL -> HLHLHLHLHL
++
++   The upshot of this is, there is no way to determine the required
++   length of the input buffer from reloffset and rlelength without
++   going through the data at that scan line.
++
++   Furthermore, there's no requirement that individual scan lines
++   pointed to from the rleoffset table are in any sort of order or
++   used only once, or even disjoint. There's also no requirement that
++   all of the data in the scan line area of the image file be used
++
++ */
++
++static int expandrow(UINT8* dest, UINT8* src, int n, int z, int xsize, UINT8 *end_of_buffer)
+ {
++    /*
++     * n here is the number of rlechunks
++     * z is the number of channels, for calculating the interleave
++     *   offset to go to RGBA style pixels
++     * xsize is the row width
++     * end_of_buffer is the address of the end of the input buffer
++     */
++
+     UINT8 pixel, count;
+     int x = 0;
+ 
+     for (;n > 0; n--)
+     {
++        if (src > end_of_buffer) {
++            return -1;
++        }
+         pixel = *src++;
+         if (n == 1 && pixel != 0)
+             return n;
+@@ -43,6 +90,9 @@
+         }
+         x += count;
+         if (pixel & RLE_COPY_FLAG) {
++            if (src + count > end_of_buffer) {
++                return -1;
++            }
+             while(count--) {
+                 *dest = *src++;
+                 dest += z;
+@@ -50,6 +100,9 @@
+ 
+         }
+         else {
++            if (src > end_of_buffer) {
++                return -1;
++            }
+             pixel = *src++;
+             while (count--) {
+                 *dest = pixel;
+@@ -61,7 +114,7 @@
+     return 0;
+ }
+ 
+-static int expandrow2(UINT8* dest, const UINT8* src, int n, int z, int xsize)
++static int expandrow2(UINT8* dest, const UINT8* src, int n, int z, int xsize, UINT8 *end_of_buffer)
+ {
+     UINT8 pixel, count;
+ 
+@@ -69,6 +122,9 @@
+ 
+     for (;n > 0; n--)
+     {
++        if (src + 1 > end_of_buffer) {
++            return -1;
++        }
+         pixel = src[1];
+         src+=2;
+         if (n == 1 && pixel != 0)
+@@ -81,6 +137,9 @@
+         }
+         x += count;
+         if (pixel & RLE_COPY_FLAG) {
++            if (src + 2 * count > end_of_buffer) {
++                return -1;
++            }
+             while(count--) {
+                 memcpy(dest, src, 2);
+                 src += 2;
+@@ -88,6 +147,9 @@
+             }
+         }
+         else {
++            if (src + 2 > end_of_buffer) {
++                return -1;
++            }
+             while (count--) {
+                 memcpy(dest, src, 2);
+                 dest += z * 2;
+@@ -137,9 +199,11 @@
+         return -1;
+     }
+     _imaging_seek_pyFd(state->fd, SGI_HEADER_SIZE, SEEK_SET);
+-    _imaging_read_pyFd(state->fd, (char*)ptr, c->bufsize);
++    if (_imaging_read_pyFd(state->fd, (char *)ptr, c->bufsize) != c->bufsize) {
++        state->errcode = IMAGING_CODEC_UNKNOWN;
++        return -1;
++    }
+ 
+-
+     /* decoder initialization */
+     state->count = 0;
+     state->y = 0;
+@@ -169,8 +233,6 @@
+     for (c->tabindex = 0, c->bufindex = c->tablen * sizeof(UINT32); c->tabindex < c->tablen; c->tabindex++, c->bufindex+=4)
+         read4B(&c->lengthtab[c->tabindex], &ptr[c->bufindex]);
+ 
+-    state->count += c->tablen * sizeof(UINT32) * 2;
+-
+     /* read compressed rows */
+     for (c->rowno = 0; c->rowno < im->ysize; c->rowno++, state->y += state->ystep)
+     {
+@@ -178,19 +240,21 @@
+         {
+             c->rleoffset = c->starttab[c->rowno + c->channo * im->ysize];
+             c->rlelength = c->lengthtab[c->rowno + c->channo * im->ysize];
+-            c->rleoffset -= SGI_HEADER_SIZE;
+ 
+-            if (c->rleoffset + c->rlelength > c->bufsize) {
++            // Check for underflow of rleoffset-SGI_HEADER_SIZE
++            if (c->rleoffset < SGI_HEADER_SIZE) {
+                 state->errcode = IMAGING_CODEC_OVERRUN;
+                 goto sgi_finish_decode;
+             }
+ 
++            c->rleoffset -= SGI_HEADER_SIZE;
++
+             /* row decompression */
+             if (c->bpc ==1) {
+-                status = expandrow(&state->buffer[c->channo], &ptr[c->rleoffset], c->rlelength, im->bands, im->xsize);
++                status = expandrow(&state->buffer[c->channo], &ptr[c->rleoffset], c->rlelength, im->bands, im->xsize, &ptr[c->bufsize-1]);
+             }
+             else {
+-                status = expandrow2(&state->buffer[c->channo * 2], &ptr[c->rleoffset], c->rlelength, im->bands, im->xsize);
++                status = expandrow2(&state->buffer[c->channo * 2], &ptr[c->rleoffset], c->rlelength, im->bands, im->xsize, &ptr[c->bufsize-1]);
+             }
+             if (status == -1) {
+                 state->errcode = IMAGING_CODEC_OVERRUN;
+@@ -199,7 +263,6 @@
+                 goto sgi_finish_decode;
+             }
+ 
+-            state->count += c->rlelength;
+         }
+ 
+         /* store decompressed data in image */
+@@ -207,7 +270,6 @@
+ 
+     }
+ 
+-    c->bufsize++;
+ 
+ sgi_finish_decode: ;
+ 
+@@ -218,5 +280,5 @@
+         state->errcode=err;
+         return -1;
+     }
+-    return state->count - c->bufsize;
++    return 0;
+ }

--- a/plone/patches/CVE-2021-27921_27922_27923.patch
+++ b/plone/patches/CVE-2021-27921_27922_27923.patch
@@ -1,0 +1,42 @@
+CVE-2021-27921 reported size of a contained image is not properly checked for a BLP container
+CVE-2021-27922 reported size of a contained image is not properly checked for an ICNS container
+CVE-2021-27923 reported size of a contained image is not properly checked for an ICO container
+
+--- a/src/PIL/BlpImagePlugin.py
++++ b/src/PIL/BlpImagePlugin.py
+@@ -353,6 +353,7 @@
+         data = jpeg_header + data
+         data = BytesIO(data)
+         image = JpegImageFile(data)
++        Image._decompression_bomb_check(image.size)
+         self.tile = image.tile  # :/
+         self.fd = image.fp
+         self.mode = image.mode
+--- a/src/PIL/IcnsImagePlugin.py
++++ b/src/PIL/IcnsImagePlugin.py
+@@ -105,6 +105,7 @@
+     if sig[:8] == b"\x89PNG\x0d\x0a\x1a\x0a":
+         fobj.seek(start)
+         im = PngImagePlugin.PngImageFile(fobj)
++        Image._decompression_bomb_check(im.size)
+         return {"RGBA": im}
+     elif (
+         sig[:4] == b"\xff\x4f\xff\x51"
+@@ -121,6 +122,7 @@
+         jp2kstream = fobj.read(length)
+         f = io.BytesIO(jp2kstream)
+         im = Jpeg2KImagePlugin.Jpeg2KImageFile(f)
++        Image._decompression_bomb_check(im.size)
+         if im.mode != "RGBA":
+             im = im.convert("RGBA")
+         return {"RGBA": im}
+--- a/src/PIL/IcoImagePlugin.py
++++ b/src/PIL/IcoImagePlugin.py
+@@ -177,6 +177,7 @@
+         if data[:8] == PngImagePlugin._MAGIC:
+             # png frame
+             im = PngImagePlugin.PngImageFile(self.buf)
++            Image._decompression_bomb_check(im.size)
+         else:
+             # XOR + AND mask bmp frame
+             im = BmpImagePlugin.DibImageFile(self.buf)

--- a/plone/patches/CVE-2021-28675.patch
+++ b/plone/patches/CVE-2021-28675.patch
@@ -1,0 +1,128 @@
+CVE-2021-28675 DoS in PsdImagePlugin
+
+--- a/src/PIL/ImageFile.py
++++ b/src/PIL/ImageFile.py
+@@ -543,12 +543,18 @@
+ 
+     :param fp: File handle.  Must implement a <b>read</b> method.
+     :param size: Number of bytes to read.
+-    :returns: A string containing up to <i>size</i> bytes of data.
++    :returns: A string containing <i>size</i> bytes of data.
++
++    Raises an OSError if the file is truncated and the read can not be completed
++
+     """
+     if size <= 0:
+         return b""
+     if size <= SAFEBLOCK:
+-        return fp.read(size)
++        data = fp.read(size)
++        if len(data) < size:
++            raise OSError("Truncated File Read")
++        return data
+     data = []
+     while size > 0:
+         block = fp.read(min(size, SAFEBLOCK))
+@@ -556,6 +562,8 @@
+             break
+         data.append(block)
+         size -= len(block)
++    if sum(len(d) for d in data) < size:
++        raise OSError("Truncated File Read")
+     return b"".join(data)
+ 
+
+--- a/src/PIL/PsdImagePlugin.py
++++ b/src/PIL/PsdImagePlugin.py
+@@ -22,6 +22,8 @@
+ 
+ import io
+ 
++import io
++
+ from . import Image, ImageFile, ImagePalette
+ from ._binary import i8, i16be as i16, i32be as i32
+ 
+@@ -121,7 +123,8 @@
+             end = self.fp.tell() + size
+             size = i32(read(4))
+             if size:
+-                self.layers = _layerinfo(self.fp)
++                _layer_data = io.BytesIO(ImageFile._safe_read(self.fp, size))
++                self.layers = _layerinfo(_layer_data, size)
+             self.fp.seek(end)
+ 
+         #
+@@ -179,12 +182,21 @@
+             self.__fp = None
+ 
+ 
+-def _layerinfo(file):
++def _layerinfo(fp, ct_bytes):
+     # read layerinfo block
+     layers = []
+-    read = file.read
+-    for i in range(abs(i16(read(2)))):
+ 
++    def read(size):
++        return ImageFile._safe_read(fp, size)
++
++    ct = i16(read(2))
++
++    # sanity check
++    if ct_bytes < (abs(ct) * 20):
++        raise SyntaxError("Layer block too short for number of layers requested")
++
++    for i in range(abs(ct)):
++
+         # bounding box
+         y0 = i32(read(4))
+         x0 = i32(read(4))
+@@ -194,7 +206,8 @@
+         # image info
+         info = []
+         mode = []
+-        types = list(range(i16(read(2))))
++        ct_types = i16(read(2))
++        types = list(range(ct_types))
+         if len(types) > 4:
+             continue
+ 
+@@ -227,16 +240,16 @@
+         size = i32(read(4))  # length of the extra data field
+         combined = 0
+         if size:
+-            data_end = file.tell() + size
++            data_end = fp.tell() + size
+ 
+             length = i32(read(4))
+             if length:
+-                file.seek(length - 16, io.SEEK_CUR)
++                fp.seek(length - 16, io.SEEK_CUR)
+             combined += length + 4
+ 
+             length = i32(read(4))
+             if length:
+-                file.seek(length, io.SEEK_CUR)
++                fp.seek(length, io.SEEK_CUR)
+             combined += length + 4
+ 
+             length = i8(read(1))
+@@ -246,7 +259,7 @@
+                 name = read(length).decode("latin-1", "replace")
+             combined += length + 1
+ 
+-            file.seek(data_end)
++            fp.seek(data_end)
+         layers.append((name, mode, (x0, y0, x1, y1)))
+ 
+     # get tiles
+@@ -254,7 +267,7 @@
+     for name, mode, bbox in layers:
+         tile = []
+         for m in mode:
+-            t = _maketile(file, m, bbox, 1)
++            t = _maketile(fp, m, bbox, 1)
+             if t:
+                 tile.extend(t)
+         layers[i] = name, mode, bbox, tile

--- a/plone/patches/CVE-2021-28676.patch
+++ b/plone/patches/CVE-2021-28676.patch
@@ -1,0 +1,16 @@
+CVE-2021-28676 infinite loop in FliDecode.c can lead to DoS
+
+--- a/src/libImaging/FliDecode.c
++++ b/src/libImaging/FliDecode.c
+@@ -208,6 +208,11 @@
+ 	    return -1;
+ 	}
+ 	advance = I32(ptr);
++	if (advance == 0 ) {
++	    // If there's no advance, we're in in infinite loop
++	    state->errcode = IMAGING_CODEC_BROKEN;
++	    return -1;
++	}
+ 	ptr += advance;
+ 	bytes -= advance;
+     }

--- a/plone/patches/CVE-2021-28677.patch
+++ b/plone/patches/CVE-2021-28677.patch
@@ -1,0 +1,29 @@
+CVE-2021-28677 DoS in the open phase via a malicious EPS file
+
+--- a/src/PIL/EpsImagePlugin.py
++++ b/src/PIL/EpsImagePlugin.py
+@@ -183,12 +183,12 @@
+         self.fp.seek(offset, whence)
+ 
+     def readline(self):
+-        s = self.char or b""
++        s = [self.char or b""]
+         self.char = None
+ 
+         c = self.fp.read(1)
+-        while c not in b"\r\n":
+-            s = s + c
++        while (c not in b"\r\n") and len(c):
++            s.append(c)
+             c = self.fp.read(1)
+ 
+         self.char = self.fp.read(1)
+@@ -196,7 +196,7 @@
+         if self.char in b"\r\n":
+             self.char = None
+ 
+-        return s.decode("latin-1")
++        return b"".join(s).decode("latin-1")
+ 
+ 
+ def _accept(prefix):

--- a/plone/patches/CVE-2021-28678.patch
+++ b/plone/patches/CVE-2021-28678.patch
@@ -1,0 +1,109 @@
+CVE-2021-28678 improper check in BlpImagePlugin can lead to DoS
+
+--- a/src/PIL/BlpImagePlugin.py
++++ b/src/PIL/BlpImagePlugin.py
+@@ -286,33 +286,36 @@
+             raise IOError("Truncated Blp file")
+         return 0, 0
+ 
++    def _safe_read(self, length):
++        return ImageFile._safe_read(self.fd, length)
++
+     def _read_palette(self):
+         ret = []
+         for i in range(256):
+             try:
+-                b, g, r, a = struct.unpack("<4B", self.fd.read(4))
++                b, g, r, a = struct.unpack("<4B", self._safe_read(4))
+             except struct.error:
+                 break
+             ret.append((b, g, r, a))
+         return ret
+ 
+     def _read_blp_header(self):
+-        (self._blp_compression,) = struct.unpack("<i", self.fd.read(4))
++        (self._blp_compression,) = struct.unpack("<i", self._safe_read(4))
+ 
+-        (self._blp_encoding,) = struct.unpack("<b", self.fd.read(1))
+-        (self._blp_alpha_depth,) = struct.unpack("<b", self.fd.read(1))
+-        (self._blp_alpha_encoding,) = struct.unpack("<b", self.fd.read(1))
+-        (self._blp_mips,) = struct.unpack("<b", self.fd.read(1))
++        (self._blp_encoding,) = struct.unpack("<b", self._safe_read(1))
++        (self._blp_alpha_depth,) = struct.unpack("<b", self._safe_read(1))
++        (self._blp_alpha_encoding,) = struct.unpack("<b", self._safe_read(1))
++        (self._blp_mips,) = struct.unpack("<b", self._safe_read(1))
+ 
+-        self.size = struct.unpack("<II", self.fd.read(8))
++        self.size = struct.unpack("<II", self._safe_read(8))
+ 
+         if self.magic == b"BLP1":
+             # Only present for BLP1
+-            (self._blp_encoding,) = struct.unpack("<i", self.fd.read(4))
+-            (self._blp_subtype,) = struct.unpack("<i", self.fd.read(4))
++            (self._blp_encoding,) = struct.unpack("<i", self._safe_read(4))
++            (self._blp_subtype,) = struct.unpack("<i", self._safe_read(4))
+ 
+-        self._blp_offsets = struct.unpack("<16I", self.fd.read(16 * 4))
+-        self._blp_lengths = struct.unpack("<16I", self.fd.read(16 * 4))
++        self._blp_offsets = struct.unpack("<16I", self._safe_read(16 * 4))
++        self._blp_lengths = struct.unpack("<16I", self._safe_read(16 * 4))
+ 
+ 
+ class BLP1Decoder(_BLPBaseDecoder):
+@@ -324,7 +327,7 @@
+             if self._blp_encoding in (4, 5):
+                 data = bytearray()
+                 palette = self._read_palette()
+-                _data = BytesIO(self.fd.read(self._blp_lengths[0]))
++                _data = BytesIO(self._safe_read(self._blp_lengths[0]))
+                 while True:
+                     try:
+                         (offset,) = struct.unpack("<B", _data.read(1))
+@@ -346,10 +349,10 @@
+     def _decode_jpeg_stream(self):
+         from PIL.JpegImagePlugin import JpegImageFile
+ 
+-        (jpeg_header_size,) = struct.unpack("<I", self.fd.read(4))
+-        jpeg_header = self.fd.read(jpeg_header_size)
+-        self.fd.read(self._blp_offsets[0] - self.fd.tell())  # What IS this?
+-        data = self.fd.read(self._blp_lengths[0])
++        jpeg_header_size, = struct.unpack("<I", self._safe_read(4))
++        jpeg_header = self._safe_read(jpeg_header_size)
++        self._safe_read(self._blp_offsets[0] - self.fd.tell())  # What IS this?
++        data = self._safe_read(self._blp_lengths[0])
+         data = jpeg_header + data
+         data = BytesIO(data)
+         image = JpegImageFile(data)
+@@ -370,7 +373,7 @@
+             # Uncompressed or DirectX compression
+ 
+             if self._blp_encoding == BLP_ENCODING_UNCOMPRESSED:
+-                _data = BytesIO(self.fd.read(self._blp_lengths[0]))
++                _data = BytesIO(self._safe_read(self._blp_lengths[0]))
+                 while True:
+                     try:
+                         (offset,) = struct.unpack("<B", _data.read(1))
+@@ -384,20 +387,20 @@
+                     linesize = (self.size[0] + 3) // 4 * 8
+                     for yb in range((self.size[1] + 3) // 4):
+                         for d in decode_dxt1(
+-                            self.fd.read(linesize), alpha=bool(self._blp_alpha_depth)
++                            self._safe_read(linesize), alpha=bool(self._blp_alpha_depth)
+                         ):
+                             data += d
+ 
+                 elif self._blp_alpha_encoding == BLP_ALPHA_ENCODING_DXT3:
+                     linesize = (self.size[0] + 3) // 4 * 16
+                     for yb in range((self.size[1] + 3) // 4):
+-                        for d in decode_dxt3(self.fd.read(linesize)):
++                        for d in decode_dxt3(self._safe_read(linesize)):
+                             data += d
+ 
+                 elif self._blp_alpha_encoding == BLP_ALPHA_ENCODING_DXT5:
+                     linesize = (self.size[0] + 3) // 4 * 16
+                     for yb in range((self.size[1] + 3) // 4):
+-                        for d in decode_dxt5(self.fd.read(linesize)):
++                        for d in decode_dxt5(self._safe_read(linesize)):
+                             data += d
+                 else:
+                     raise BLPFormatError(

--- a/plone/patches/CVE-2021-34552.patch
+++ b/plone/patches/CVE-2021-34552.patch
@@ -1,0 +1,34 @@
+CVE-2021-34552: buffer overflow in Convert.c because it allow an attacker to pass
+controlled parameters directly into a convert function
+
+--- a/src/libImaging/Convert.c
++++ b/src/libImaging/Convert.c
+@@ -1623,9 +1623,8 @@
+         return (Imaging) ImagingError_ValueError("conversion not supported");
+ #else
+     {
+-      static char buf[256];
+-      /* FIXME: may overflow if mode is too large */
+-      sprintf(buf, "conversion from %s to %s not supported", imIn->mode, mode);
++      static char buf[100];
++      snprintf(buf, 100, "conversion from %.10s to %.10s not supported", imIn->mode, mode);
+       return (Imaging) ImagingError_ValueError(buf);
+     }
+ #endif
+@@ -1681,9 +1680,13 @@
+     }
+ #else
+     {
+-      static char buf[256];
+-      /* FIXME: may overflow if mode is too large */
+-      sprintf(buf, "conversion from %s to %s not supported in convert_transparent", imIn->mode, mode);
++      static char buf[100];
++      snprintf(
++        buf,
++        100,
++        "conversion from %.10s to %.10s not supported in convert_transparent",
++        imIn->mode,
++        mode);
+       return (Imaging) ImagingError_ValueError(buf);
+     }
+ #endif

--- a/plone/patches/CVE-2022-22815_CVE-2022-22816.patch
+++ b/plone/patches/CVE-2022-22815_CVE-2022-22816.patch
@@ -1,0 +1,68 @@
+# CVE-2022-22815 python-pillow: improperly initializes ImagePath.Path in path_getbbox() in path.c
+# CVE-2022-22816 python-pillow: buffer over-read during initialization of ImagePath.Path in path_getbbox() in path.c
+
+--- a/Tests/test_imagepath.py
++++ b/Tests/test_imagepath.py
+@@ -65,6 +65,11 @@
+             p = ImagePath.Path(arr.tostring())
+         self.assertEqual(list(p), [(0.0, 1.0)])
+ 
++    def test_getbbox(self):
++        for coords in (0,1):
++            p = ImagePath.Path(coords)
++            self.assertEqual(p.getbbox(), (0.0, 0.0, 0.0, 0.0))
++
+     def test_overflow_segfault(self):
+         # Some Pythons fail getting the argument as an integer, and it falls
+         # through to the sequence. Seeing this on 32-bit Windows.
+--- a/src/path.c
++++ b/src/path.c
+@@ -62,7 +62,7 @@ alloc_array(Py_ssize_t count)
+         PyErr_NoMemory();
+         return NULL;
+     }
+-    xy = malloc(2 * count * sizeof(double) + 1);
++    xy = calloc(2 * count + 1, sizeof(double));
+     if (!xy)
+         PyErr_NoMemory();
+     return xy;
+@@ -330,18 +330,27 @@ path_getbbox(PyPathObject* self, PyObject* args)
+ 
+     xy = self->xy;
+ 
+-    x0 = x1 = xy[0];
+-    y0 = y1 = xy[1];
+-
+-    for (i = 1; i < self->count; i++) {
+-        if (xy[i+i] < x0)
+-            x0 = xy[i+i];
+-        if (xy[i+i] > x1)
+-            x1 = xy[i+i];
+-        if (xy[i+i+1] < y0)
+-            y0 = xy[i+i+1];
+-        if (xy[i+i+1] > y1)
+-            y1 = xy[i+i+1];
++    if (self->count == 0) {
++        x0 = x1 = 0;
++        y0 = y1 = 0;
++    } else {
++        x0 = x1 = xy[0];
++        y0 = y1 = xy[1];
++
++        for (i = 1; i < self->count; i++) {
++            if (xy[i + i] < x0) {
++                x0 = xy[i + i];
++            }
++            if (xy[i + i] > x1) {
++                x1 = xy[i + i];
++            }
++            if (xy[i + i + 1] < y0) {
++                y0 = xy[i + i + 1];
++            }
++            if (xy[i + i + 1] > y1) {
++                y1 = xy[i + i + 1];
++            }
++        }
+     }
+ 
+     return Py_BuildValue("dddd", x0, y0, x1, y1);

--- a/plone/patches/CVE-2022-22817.patch
+++ b/plone/patches/CVE-2022-22817.patch
@@ -1,0 +1,39 @@
+CVE-2022-22817 PIL.ImageMath.eval allows evaluation of arbitrary expressions
+
+--- a/Tests/test_imagemath.py
++++ b/Tests/test_imagemath.py
+@@ -56,6 +56,12 @@
+             pixel(ImageMath.eval("float(B)**33", images)), "F 8589934592.0"
+         )
+ 
++    def test_prevent_exec(self):
++        self.assertRaises(ValueError, ImageMath.eval("exec('pass')"))
++        self.assertRaises(ValueError, ImageMath.eval("(lambda: exec('pass'))()"))
++        self.assertRaises(ValueError, ImageMath.eval("(lambda: (lambda: exec('pass'))())()"))
++
++
+     def test_logical(self):
+         self.assertEqual(pixel(ImageMath.eval("not A", images)), 0)
+         self.assertEqual(pixel(ImageMath.eval("A and B", images)), "L 2")
+--- a/src/PIL/ImageMath.py
++++ b/src/PIL/ImageMath.py
+@@ -264,7 +264,18 @@
+         if hasattr(v, "im"):
+             args[k] = _Operand(v)
+ 
+-    out = builtins.eval(expression, args)
++    compiled_code = compile(expression, "<string>", "eval")
++    def scan(code):
++        for const in code.co_consts:
++            if type(const) == type(compiled_code):
++                scan(const)
++
++        for name in code.co_names:
++            if name not in args and name != "abs":
++                raise ValueError(f"'{name}' not allowed")
++
++    scan(compiled_code)
++    out = builtins.eval(expression, {"__builtins": {"abs": abs}}, args)
+     try:
+         return out.im
+     except AttributeError:

--- a/plone/patches/CVE-2023-44271.patch
+++ b/plone/patches/CVE-2023-44271.patch
@@ -1,0 +1,77 @@
+CVE-2023-44271 python-pillow: uncontrolled resource consumption when textlength
+in an ImageDraw instance operates on a long text argument
+
+--- a/docs/reference/ImageFont.rst
++++ b/docs/reference/ImageFont.rst
+@@ -17,6 +17,15 @@ OpenType fonts (as well as other font formats supported by the FreeType
+ library). For earlier versions, TrueType support is only available as part of
+ the imToolkit package
+ 
++.. warning::
++    To protect against potential DOS attacks when using arbitrary strings as
++    text input, Pillow will raise a ``ValueError`` if the number of characters
++    is over a certain limit, :py:data:`MAX_STRING_LENGTH`.
++
++    This threshold can be changed by setting
++    :py:data:`MAX_STRING_LENGTH`. It can be disabled by setting
++    ``ImageFont.MAX_STRING_LENGTH = None``.
++
+ Example
+ -------
+
+--- a/src/PIL/ImageFont.py
++++ b/src/PIL/ImageFont.py
+@@ -40,13 +40,21 @@
+     def __getattr__(self, id):
+         raise ImportError("The _imagingft C module is not installed")
+ 
++MAX_STRING_LENGTH = 1_000_000
+ 
++
+ try:
+     from . import _imagingft as core
+ except ImportError:
+     core = _imagingft_not_installed()
+ 
+ 
++def _string_length_check(text):
++    if MAX_STRING_LENGTH is not None and len(text) > MAX_STRING_LENGTH:
++        msg = "too many characters in string"
++        raise ValueError(msg)
++
++
+ # FIXME: add support for pilfont2 format (see FontFile.py)
+ 
+ # --------------------------------------------------------------------
+@@ -117,6 +125,7 @@
+ 
+         :return: (width, height)
+         """
++        _string_length_check(text)
+         return self.font.getsize(text)
+ 
+     def getmask(self, text, mode="", *args, **kwargs):
+@@ -251,6 +260,7 @@
+ 
+         :return: (width, height)
+         """
++        _string_length_check(text)
+         size, offset = self.font.getsize(text, direction, features, language)
+         return (
+             size[0] + stroke_width * 2 + offset[0],
+@@ -460,6 +470,7 @@
+                  :py:mod:`PIL.Image.core` interface module, and the text offset, the
+                  gap between the starting coordinate and the first marking
+         """
++        _string_length_check(text)
+         size, offset = self.font.getsize(text, direction, features, language)
+         size = size[0] + stroke_width * 2, size[1] + stroke_width * 2
+         im = fill("L", size, 0)
+@@ -559,6 +570,7 @@
+         self.orientation = orientation  # any 'transpose' argument, or None
+ 
+     def getsize(self, text, *args, **kwargs):
++        _string_length_check(text)
+         w, h = self.font.getsize(text)
+         if self.orientation in (Image.ROTATE_90, Image.ROTATE_270):
+             return h, w

--- a/plone/patches/CVE-2023-50447.patch
+++ b/plone/patches/CVE-2023-50447.patch
@@ -1,0 +1,30 @@
+CVE-2023-50447 python-pillow: pillow:Arbitrary Code Execution via the environment parameter
+
+--- a/Tests/test_imagemath.py
++++ b/Tests/test_imagemath.py
+@@ -61,6 +61,11 @@
+         self.assertRaises(ValueError, ImageMath.eval("(lambda: exec('pass'))()"))
+         self.assertRaises(ValueError, ImageMath.eval("(lambda: (lambda: exec('pass'))())()"))
+ 
++    def test_prevent_double_underscores(self):
++        self.assertRaises(ValueError, ImageMath.eval("1", {"__": None}))
++    
++    def test_prevent_builtins(self):
++        self.assertRaises(ValueError, ImageMath.eval("(lambda: exec('exit()'))()", {"exec": None}))
+ 
+     def test_logical(self):
+         self.assertEqual(pixel(ImageMath.eval("not A", images)), 0)
+--- a/src/PIL/ImageMath.py
++++ b/src/PIL/ImageMath.py
+@@ -258,6 +258,11 @@
+ 
+     # build execution namespace
+     args = ops.copy()
++    for k in list(_dict.keys()) + list(kw.keys()):
++        if "__" in k or hasattr(builtins, k):
++            msg = f"'{k}' not allowed"
++            raise ValueError(msg)
++
+     args.update(_dict)
+     args.update(kw)
+     for k, v in list(args.items()):

--- a/plone/patches/z3c_autoinclude_utils.py
+++ b/plone/patches/z3c_autoinclude_utils.py
@@ -1,0 +1,251 @@
+# Copied from z3c.autoinclude 0.4.0
+# distributionForDottedName() is insanely slow if packages are installed in
+# a single location (e.g. site-packages). With this patch we cache
+# find_packages() calls for the same location, which improves startup time
+# significantly.
+from __future__ import absolute_import, print_function
+
+import os
+from pkg_resources import find_distributions
+from pprint import pformat
+import sys
+
+_PACKAGES = {}
+
+
+class DistributionManager(object):
+    def __init__(self, dist):
+        self.context = dist
+
+    def namespaceDottedNames(self):
+        """Return dotted names of all namespace packages in distribution.
+        """
+        return namespaceDottedNames(self.context)
+
+    def dottedNames(self):
+        """Return dotted names of all relevant packages in a distribution.
+
+        Relevant packages are those packages that are directly under the
+        namespace packages in the distribution, but not the namespace packages
+        themselves. If no namespace packages exist, return those packages that
+        are directly in the distribution.
+        """
+        dist_path = self.context.location
+        ns_dottednames = self.namespaceDottedNames()
+        if not ns_dottednames:
+            return subpackageDottedNames(dist_path)
+        result = []
+        for ns_dottedname in ns_dottednames:
+            path = os.path.join(dist_path, *ns_dottedname.split('.'))
+            subpackages = subpackageDottedNames(path, ns_dottedname)
+            for subpackage in subpackages:
+                if subpackage not in ns_dottednames:
+                    result.append(subpackage)
+        return result
+
+
+class ZCMLInfo(dict):
+    def __init__(self, zcml_to_look_for):
+        dict.__init__(self)
+        for zcml_group in zcml_to_look_for:
+            self[zcml_group] = []
+
+    def __bool__(self):
+        return any(self.values())
+
+    # For Python 2:
+    __nonzero__ = __bool__
+
+
+def subpackageDottedNames(package_path, ns_dottedname=None):
+    # we do not look for subpackages in zipped eggs
+    if not isUnzippedEgg(package_path):
+        return []
+
+    result = []
+    for subpackage_name in os.listdir(package_path):
+        full_path = os.path.join(package_path, subpackage_name)
+        if isPythonPackage(full_path):
+            if ns_dottedname:
+                result.append('%s.%s' % (ns_dottedname, subpackage_name))
+            else:
+                result.append(subpackage_name)
+    return sorted(result)
+
+
+def isPythonPackage(path):
+    if not os.path.isdir(path):
+        return False
+    for init_variant in ['__init__.py', '__init__.pyc', '__init__.pyo']:
+        if os.path.isfile(os.path.join(path, init_variant)):
+            return True
+    return False
+
+
+def distributionForPackage(package):
+    package_dottedname = package.__name__
+    return distributionForDottedName(package_dottedname)
+
+
+def distributionForDottedName(package_dottedname):
+    """
+    This function is ugly and probably slow. It needs to be heavily
+    commented, it needs narrative doctests, it needs some broad
+    explanation, and it is arbitrary in some namespace cases.
+    Then it needs to be profiled.
+    """
+    valid_dists_for_package = []
+    for path in sys.path:
+        dists = find_distributions(path, True)
+        for dist in dists:
+            if not isUnzippedEgg(dist.location):
+                continue
+            if dist.location in _PACKAGES:
+                packages = _PACKAGES[dist.location]
+            else:
+                packages = find_packages(dist.location)
+                _PACKAGES[dist.location] = packages
+            ns_packages = namespaceDottedNames(dist)
+            # if package_dottedname in ns_packages:
+            # continue
+            if package_dottedname not in packages:
+                continue
+            valid_dists_for_package.append((dist, ns_packages))
+
+    if len(valid_dists_for_package) == 0:
+        raise LookupError(
+            "No distributions found for package `%s`; are you sure it is importable?"
+            % package_dottedname
+        )
+
+    if len(valid_dists_for_package) > 1:
+        non_namespaced_dists = [
+            (dist, ns_packages)
+            for dist, ns_packages in valid_dists_for_package
+            if len(ns_packages) == 0
+        ]
+        if len(non_namespaced_dists) == 0:
+            # if we only have namespace packages at this point,
+            # 'foo.bar' and 'foo.baz', while looking for 'foo', we can
+            # just select the first because the choice has no effect.
+            # However, if possible, we prefer to select the one that matches the package name
+            # if it's the "root" namespace
+            if '.' not in package_dottedname:
+                for dist, _ in valid_dists_for_package:
+                    if dist.project_name == package_dottedname:
+                        return dist
+
+            # Otherwise, to be deterministic (because the order depends on both sys.path
+            # and `find_distributions`) we will sort them by project_name and return
+            # the first value.
+            valid_dists_for_package.sort(key=lambda dist_ns: dist_ns[0].project_name)
+
+            return valid_dists_for_package[0][0]
+
+        valid_dists_for_package = (
+            non_namespaced_dists
+        )  ### if we have packages 'foo', 'foo.bar', and 'foo.baz', the correct one is 'foo'.
+
+        ### we really are in trouble if we get into a situation with more than one non-namespaced package at this point.
+        error_msg = '''
+Multiple distributions were found that claim to provide the `%s` package.
+This is most likely because one or more of them uses `%s` as a namespace package,
+but forgot to declare it in the `namespace_packages` section of its `setup.py`.
+Please make any necessary adjustments and reinstall the modified distribution(s).
+
+Distributions found: %s
+'''
+
+        assert len(non_namespaced_dists) == 1, error_msg % (
+            package_dottedname,
+            package_dottedname,
+            pformat(non_namespaced_dists),
+        )
+
+    return valid_dists_for_package[0][0]
+
+
+def namespaceDottedNames(dist):
+    """
+    Return a list of dotted names of all namespace packages in a distribution.
+    """
+    try:
+        ns_dottednames = list(dist.get_metadata_lines('namespace_packages.txt'))
+    except IOError:
+        ns_dottednames = []
+    except KeyError:
+        ns_dottednames = []
+    return ns_dottednames
+
+
+def isUnzippedEgg(path):
+    """
+    Check whether a filesystem path points to an unzipped egg; z3c.autoinclude
+    does not support zipped eggs or python libraries that are not packaged as
+    eggs. This function can be called on e.g. entries in sys.path or the
+    location of a distribution object.
+    """
+    return os.path.isdir(path)
+
+
+### cargo-culted from setuptools 0.6c9's __init__.py;
+#   importing setuptools is unsafe, but i can't find any
+#   way to get the information that find_packages provides
+#   using pkg_resources and i can't figure out a way to
+#   avoid needing it.
+from distutils.util import convert_path
+
+
+def find_packages(where='.', exclude=()):
+    """Return a list all Python packages found within directory 'where'
+
+    'where' should be supplied as a "cross-platform" (i.e. URL-style) path; it
+    will be converted to the appropriate local path syntax.  'exclude' is a
+    sequence of package names to exclude; '*' can be used as a wildcard in the
+    names, such that 'foo.*' will exclude all subpackages of 'foo' (but not
+    'foo' itself).
+    """
+    out = []
+    stack = [(convert_path(where), '')]
+    while stack:
+        where, prefix = stack.pop(0)
+        for name in os.listdir(where):
+            fn = os.path.join(where, name)
+            if (
+                '.' not in name
+                and os.path.isdir(fn)
+                and os.path.isfile(os.path.join(fn, '__init__.py'))
+            ):
+                out.append(prefix + name)
+                stack.append((fn, prefix + name + '.'))
+    for pat in list(exclude) + ['ez_setup']:
+        from fnmatch import fnmatchcase
+
+        out = [item for item in out if not fnmatchcase(item, pat)]
+    return out
+
+
+def create_report(info):
+    """Create a report with a list of auto included zcml."""
+    if not info:
+        # Return a comment.  Maybe someone wants to automatically include this
+        # in a zcml file, so make it a proper xml comment.
+        return ["<!-- No zcml files found to include. -->"]
+    report = []
+    # Try to report meta.zcml first.
+    filenames = list(info)
+    meta = "meta.zcml"
+    if meta in filenames:
+        filenames.remove(meta)
+        filenames.insert(0, meta)
+    for filename in filenames:
+        dotted_names = info[filename]
+        for dotted_name in dotted_names:
+            if filename == "overrides.zcml":
+                line = '  <includeOverrides package="%s" file="%s" />' % (dotted_name, filename)
+            elif filename == "configure.zcml":
+                line = '  <include package="%s" />'% dotted_name
+            else:
+                line = '  <include package="%s" file="%s" />'% (dotted_name, filename)
+            report.append(line)
+    return report

--- a/plone/versions.txt
+++ b/plone/versions.txt
@@ -80,7 +80,7 @@ PasteScript==1.7.5
 pep8==1.5.7
 Persistence==2.13.2
 PIL==1.1.7
-Pillow==3.3.3
+Pillow==6.2.2
 plone.alterego==1.1.5
 plone.api==1.10.2
 plone.app.blob==1.5.19

--- a/plone/versions.txt
+++ b/plone/versions.txt
@@ -286,7 +286,7 @@ urllib3==1.22
 WebOb==1.4.2
 wicked==1.1.12
 wsgi-intercept==0.4
-z3c.autoinclude==0.4.0
+z3c.autoinclude==0.4.1
 z3c.batching==1.1.0
 z3c.blobfile==0.1.5
 z3c.caching==2.0

--- a/zeoserver/Dockerfile
+++ b/zeoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 as build-stage
+FROM 4teamwork/python:2.7 as build-stage
 
 RUN addgroup -S -g 800 plone \
  && adduser -S -D -G plone -u 800 plone
@@ -8,37 +8,30 @@ RUN mkdir -p /app
 RUN apk add --virtual .build-deps \
     gcc \
     libc-dev \
-    zlib-dev \
-    python2-dev \
-    py2-setuptools
+    zlib-dev
 
 WORKDIR /app
 
-RUN wget https://bootstrap.pypa.io/virtualenv/2.7/virtualenv.pyz \
- && python virtualenv.pyz . \
- && rm virtualenv.pyz
-
-ENV VIRTUAL_ENV=/app
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
 COPY versions.txt ./
 
-RUN --mount=type=cache,target=/root/.cache pip install ZODB3 -c versions.txt
+RUN echo "/app/lib/python2.7/site-packages/" > /usr/local/lib/python2.7/site-packages/app.pth
+
+RUN --mount=type=cache,target=/root/.cache pip install --prefix /app ZODB3 -c versions.txt
 
 RUN mkdir -p /app/var
 RUN chown -R plone:plone /app/var
 COPY etc /app/etc
 COPY docker-entrypoint.sh /app/
 
-FROM alpine:3.14
+
+FROM 4teamwork/python:2.7
 
 RUN addgroup -S -g 800 plone \
  && adduser -S -D -G plone -u 800 plone
 
-RUN apk add \
-    python2
-
 COPY --from=build-stage /app /app
+RUN echo "/app/lib/python2.7/site-packages/" > /usr/local/lib/python2.7/site-packages/app.pth \
+ && echo "import site; site.addsitedir('/app/lib/python2.7/site-packages')" > /usr/local/lib/python2.7/site-packages/sitecustomize.py
 
 RUN mkdir -p /data \
  && chown -R plone:plone /data

--- a/zeoserver/versions.txt
+++ b/zeoserver/versions.txt
@@ -285,7 +285,7 @@ urllib3==1.22
 WebOb==1.4.2
 wicked==1.1.12
 wsgi-intercept==0.4
-z3c.autoinclude==0.4.0
+z3c.autoinclude==0.4.1
 z3c.batching==1.1.0
 z3c.blobfile==0.1.5
 z3c.caching==2.0

--- a/zeoserver/versions.txt
+++ b/zeoserver/versions.txt
@@ -80,7 +80,7 @@ PasteScript==1.7.5
 pep8==1.5.7
 Persistence==2.13.2
 PIL==1.1.7
-Pillow==3.3.3
+Pillow==6.2.2
 plone.alterego==1.1.5
 plone.api==1.10.2
 plone.app.blob==1.5.19


### PR DESCRIPTION
Python 2.7 is no longer provided by Alpine. Therefore we compile it ourselves in a [base image](https://github.com/4teamwork/python27-docker) with backports of the latest security patches.

Packages are no longer installed inside a virtualenv, instead the `--prefix` option of Pip is used to install them under `/app`.

Pillow 6.2.2 is included with the latest backports of security patches.

Add support for running `zopectl` if a command is supplied. This allows us to run `zopectl` commands, e.g.
```
docker compose run --rm plone debug
docker compose run --rm plone adduser admin admin
```

No longer produce duplicate log entries in debug mode.

Reduce startup time by optimizing `z3c.autoinclude`'s package discovery.